### PR TITLE
Fixed path to etc-bind in create.sh (fixes #1)

### DIFF
--- a/cmd/create.sh
+++ b/cmd/create.sh
@@ -8,7 +8,7 @@ _EOF
 
 rename_function cmd_create orig_cmd_create
 cmd_create() {
-    cp -rn $APP_DIR/cfg/etc-bind .
+    cp -rn $APP_DIR/scripts/etc-bind .
 
     # NET_ADMIN needed for iptables
     orig_cmd_create \


### PR DESCRIPTION
in create.sh, the path for cfg/etc-bind is changed to scripts/etc-bind